### PR TITLE
fstab improvements (1/2)

### DIFF
--- a/twrp.fstab
+++ b/twrp.fstab
@@ -1,6 +1,6 @@
 /system       ext4          /dev/block/platform/soc.0/by-name/system
 /data         f2fs          /dev/block/platform/soc.0/by-name/userdata   rw,discard,nosuid,nodev,noatime,nodiratime,inline_xattr,inline_data  wait,check,encryptable=/dev/block/platform/soc.0/by-name/metadata
-/cache        ext4          /dev/block/platform/soc.0/by-name/cache
+/cache        auto          /dev/block/platform/soc.0/by-name/cache
 /boot         emmc          /dev/block/platform/soc.0/by-name/boot
 /recovery     emmc          /dev/block/platform/soc.0/by-name/recovery
 /persist      ext4          /dev/block/platform/soc.0/by-name/persist    flags=fsflags=noatime,nosuid,nodev,barrier=1,noauto_da_alloc;mounttodecrypt


### PR DESCRIPTION
ext4 shouldn't be a requirement for cache
discard removed to reduce restore time.
